### PR TITLE
Remove manually installed dependencies of tensorflow

### DIFF
--- a/dockerfiles/emloop-tensorflow
+++ b/dockerfiles/emloop-tensorflow
@@ -9,8 +9,6 @@ RUN if [ "${tag}" = "cuda" ]; then \
         pacman --noconfirm --needed -S python-tensorflow-opt; \
     fi \
     && pacman --noconfirm --needed -S tensorboard \
-    && sudo -u aur gpg --recv-keys 8C004C2F93481F6B \
-    && sudo -u aur trizen --noconfirm --needed -S python-gast python-astor python-grpcio python-termcolor \
     && paccache -rfk0
 
 # install emloop-tensorflow


### PR DESCRIPTION
Hi @petrbel, I believe this should finally fix our dockerfiles not being able to build every night. The dependencies ar fixed in the community repo.