### PR TITLE
Remove intermediate containers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,8 +22,7 @@ references:
 jobs:
 
   build:
-    machine:
-      docker_layer_caching: true
+    machine: true
     working_directory: ~/dockerfiles
     steps:
       - checkout

--- a/README.md
+++ b/README.md
@@ -17,15 +17,9 @@ All built images are stored in [Iterait DockerHub](https://hub.docker.com/r/iter
 | `iterait/tensorflow:latest`     | `iterait/tensorflow:cuda`       | `iterait/archlinux` + `tensorflow`. |
 
 ## Build
-All images may be built by regular docker build process.
-
-```bash
-$ docker build -t <image-name> -f <dockerfile> --squash .
+Build all the images by running:
 ```
-
-If you require NVIDIA CUDA support, build the image with `tag=cuda` build argument.
-```bash
-$ docker build --build-arg tag=cuda -t <image-name>:cuda -f <dockerfile> .
+./build.sh
 ```
 
 ## Run

--- a/dockerfiles/archlinuxarm/build.sh
+++ b/dockerfiles/archlinuxarm/build.sh
@@ -16,9 +16,9 @@ tar -xzf ${IMAGE_TAR} --strip-components=1 --directory=./arch-rootfs
 cp ../*.hook ./
 
 # Build the base image.
-docker build -f Dockerfile.archlinuxarm -t "iterait/archlinuxarm:${TODAY}" -t "iterait/archlinuxarm:latest" --squash .
+docker build -f Dockerfile.archlinuxarm --rm -t "iterait/archlinuxarm:${TODAY}" -t "iterait/archlinuxarm:latest" --squash .
 # Build the -dev version without context.
-docker build - -t "iterait/archlinuxarm-dev:${TODAY}" -t "iterait/archlinuxarm-dev:latest" < Dockerfile.archlinuxarm-dev
+docker build - --rm -t "iterait/archlinuxarm-dev:${TODAY}" -t "iterait/archlinuxarm-dev:latest" < Dockerfile.archlinuxarm-dev
 
 # Push the images to the repository.
 docker push iterait/archlinuxarm:latest

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -2,8 +2,8 @@
 
 TODAY="$(date '+%Y-%m-%d')"
 for imgname in archlinux archlinux-dev tensorflow; do
-    sudo docker build -f Dockerfile.${imgname} -t "iterait/${imgname}:${TODAY}" -t "iterait/${imgname}:latest" --squash .
-    sudo docker build -f Dockerfile.${imgname} --build-arg tag="cuda" -t "iterait/${imgname}:cuda_${TODAY}" -t "iterait/${imgname}:cuda" --squash .
+    sudo docker build -f Dockerfile.${imgname} --rm -t "iterait/${imgname}:${TODAY}" -t "iterait/${imgname}:latest" --squash .
+    sudo docker build -f Dockerfile.${imgname} --rm --build-arg tag="cuda" -t "iterait/${imgname}:cuda_${TODAY}" -t "iterait/${imgname}:cuda" --squash .
     if [ "${CIRCLE_BRANCH}" == "master" ]; then
         sudo docker push iterait/${imgname}:latest
         sudo docker push iterait/${imgname}:"${TODAY}"


### PR DESCRIPTION
To avoid a lot of large intermediate containers, add `--rm` to `docker build`.