### PR TITLE
Do not use docker cache when building images

### DIFF
--- a/dockerfiles/archlinuxarm/build.sh
+++ b/dockerfiles/archlinuxarm/build.sh
@@ -16,9 +16,9 @@ tar -xzf ${IMAGE_TAR} --strip-components=1 --directory=./arch-rootfs
 cp ../*.hook ./
 
 # Build the base image.
-docker build -f Dockerfile.archlinuxarm --rm -t "iterait/archlinuxarm:${TODAY}" -t "iterait/archlinuxarm:latest" --squash .
+docker build -f Dockerfile.archlinuxarm --rm --no-cache -t "iterait/archlinuxarm:${TODAY}" -t "iterait/archlinuxarm:latest" --squash .
 # Build the -dev version without context.
-docker build - --rm -t "iterait/archlinuxarm-dev:${TODAY}" -t "iterait/archlinuxarm-dev:latest" < Dockerfile.archlinuxarm-dev
+docker build - --rm --no-cache -t "iterait/archlinuxarm-dev:${TODAY}" -t "iterait/archlinuxarm-dev:latest" < Dockerfile.archlinuxarm-dev
 
 # Push the images to the repository.
 docker push iterait/archlinuxarm:latest

--- a/dockerfiles/build.sh
+++ b/dockerfiles/build.sh
@@ -2,8 +2,8 @@
 
 TODAY="$(date '+%Y-%m-%d')"
 for imgname in archlinux archlinux-dev tensorflow; do
-    sudo docker build -f Dockerfile.${imgname} --rm -t "iterait/${imgname}:${TODAY}" -t "iterait/${imgname}:latest" --squash .
-    sudo docker build -f Dockerfile.${imgname} --rm --build-arg tag="cuda" -t "iterait/${imgname}:cuda_${TODAY}" -t "iterait/${imgname}:cuda" --squash .
+    sudo docker build -f Dockerfile.${imgname} --rm --no-cache -t "iterait/${imgname}:${TODAY}" -t "iterait/${imgname}:latest" --squash .
+    sudo docker build -f Dockerfile.${imgname} --rm --no-cache --build-arg tag="cuda" -t "iterait/${imgname}:cuda_${TODAY}" -t "iterait/${imgname}:cuda" --squash .
     if [ "${CIRCLE_BRANCH}" == "master" ]; then
         sudo docker push iterait/${imgname}:latest
         sudo docker push iterait/${imgname}:"${TODAY}"


### PR DESCRIPTION
When building the images manually, they are not properly updated since the layers are retrieved from cache.